### PR TITLE
feat(spanish): add Flashcard entity and repository with derived query

### DIFF
--- a/src/main/java/com/andremunay/hobbyhub/spanish/domain/Flashcard.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/domain/Flashcard.java
@@ -1,0 +1,38 @@
+package com.andremunay.hobbyhub.spanish.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "flashcards")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Flashcard {
+
+  @Id private UUID id;
+
+  @Column(nullable = false)
+  private String front;
+
+  @Column(nullable = false)
+  private String back;
+
+  private int repetition;
+  private double easinessFactor;
+  private LocalDate nextReviewOn;
+
+  public Flashcard(UUID id, String front, String back) {
+    this.id = id;
+    this.front = front;
+    this.back = back;
+    this.repetition = 0;
+    this.easinessFactor = 2.5;
+    this.nextReviewOn = LocalDate.now();
+  }
+}

--- a/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardRepository.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardRepository.java
@@ -1,0 +1,11 @@
+package com.andremunay.hobbyhub.spanish.infra;
+
+import com.andremunay.hobbyhub.spanish.domain.Flashcard;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FlashcardRepository extends JpaRepository<Flashcard, UUID> {
+  List<Flashcard> findByNextReviewOnBefore(LocalDate dueDate);
+}

--- a/src/main/resources/db/changelog/V2__flashcard_schema.yaml
+++ b/src/main/resources/db/changelog/V2__flashcard_schema.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2
+      author: andremunay
+      changes:
+        - addColumn:
+            tableName: flashcards
+            columns:
+              - column:
+                  name: repetition
+                  type: int
+              - column:
+                  name: easiness_factor
+                  type: decimal(3,2)
+              - column:
+                  name: next_review_on
+                  type: date

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -2,4 +2,6 @@ databaseChangeLog:
   - include:
       file: db/changelog/V1__baseline.yaml
   - include:
+      file: db/changelog/V2__flashcard_schema.yaml
+  - include:
       file: db/changelog/V2__testdata.yaml


### PR DESCRIPTION
---

Define the `Flashcard` JPA entity and repository for spaced repetition review. Include fields like `front`, `back`, `nextReviewDate`, and `easeFactor`. Add a Liquibase changelog to apply the schema changes to the database.

---

### **Issue**

Closes #3 

### **Acceptance Criteria**

- [x] Flashcard entity with specified fields
- [x] JPA repository interface
- [x] Liquibase changelog `V2__flashcard_schema.yaml` adds new columns to `flashcards` table