### PR TITLE
feat(spanish): add FlashcardController with create and review endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
@@ -78,7 +81,6 @@
 			<artifactId>liquibase-core</artifactId>
 		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>
@@ -173,5 +175,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/com/andremunay/hobbyhub/spanish/app/Sm2ReviewScheduler.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/app/Sm2ReviewScheduler.java
@@ -3,7 +3,9 @@ package com.andremunay.hobbyhub.spanish.app;
 import com.andremunay.hobbyhub.spanish.domain.Flashcard;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.stereotype.Service;
 
+@Service
 public class Sm2ReviewScheduler implements ReviewScheduler {
 
   @Override

--- a/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardController.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardController.java
@@ -1,0 +1,60 @@
+package com.andremunay.hobbyhub.spanish.infra;
+
+import com.andremunay.hobbyhub.spanish.app.ReviewScheduler;
+import com.andremunay.hobbyhub.spanish.domain.Flashcard;
+import com.andremunay.hobbyhub.spanish.infra.dto.FlashcardCreateRequest;
+import com.andremunay.hobbyhub.spanish.infra.dto.FlashcardReviewDto;
+import jakarta.validation.Valid;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/flashcards")
+public class FlashcardController {
+  private final FlashcardRepository repository;
+  private final ReviewScheduler scheduler;
+
+  public FlashcardController(FlashcardRepository repository, ReviewScheduler scheduler) {
+    this.repository = repository;
+    this.scheduler = scheduler;
+  }
+
+  @PostMapping
+  public ResponseEntity<Void> create(@Valid @RequestBody FlashcardCreateRequest req) {
+    Flashcard card = new Flashcard(UUID.randomUUID(), req.getFront(), req.getBack());
+    repository.save(card);
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping
+  public ResponseEntity<List<FlashcardReviewDto>> getAll() {
+    return ResponseEntity.ok(
+        repository.findAll().stream().map(this::toDto).collect(Collectors.toList()));
+  }
+
+  @GetMapping("/review")
+  public ResponseEntity<List<FlashcardReviewDto>> getDue(@RequestParam boolean due) {
+    List<Flashcard> cards =
+        due ? repository.findByNextReviewOnBefore(LocalDate.now()) : repository.findAll();
+
+    return ResponseEntity.ok(cards.stream().map(this::toDto).collect(Collectors.toList()));
+  }
+
+  private FlashcardReviewDto toDto(Flashcard card) {
+    FlashcardReviewDto dto = new FlashcardReviewDto();
+    dto.setId(card.getId());
+    dto.setFront(card.getFront());
+    dto.setBack(card.getBack());
+    dto.setNextReviewOn(card.getNextReviewOn());
+    return dto;
+  }
+}

--- a/src/main/java/com/andremunay/hobbyhub/spanish/infra/dto/FlashcardCreateRequest.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/infra/dto/FlashcardCreateRequest.java
@@ -1,0 +1,17 @@
+package com.andremunay.hobbyhub.spanish.infra.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlashcardCreateRequest {
+  @NotBlank private String front;
+
+  @NotBlank private String back;
+}

--- a/src/main/java/com/andremunay/hobbyhub/spanish/infra/dto/FlashcardReviewDto.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/infra/dto/FlashcardReviewDto.java
@@ -1,0 +1,19 @@
+package com.andremunay.hobbyhub.spanish.infra.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FlashcardReviewDto {
+  private UUID id;
+  private String front;
+  private String back;
+  private LocalDate nextReviewOn;
+}


### PR DESCRIPTION
---

We need to expose our Spanish flashcard domain via HTTP. This issue will introduce:

1. **DTOs** for incoming requests and outgoing responses
2. A **`FlashcardController`** that supports:

   * **POST** `/flashcards` → create a new flashcard
   * **GET** `/flashcards` → retrieve all flashcards
   * **GET** `/flashcards/review?due=true` → retrieve only cards due for review

We’ll leverage Spring Validation, clean response wrapping, and map between our domain model and DTOs.

---

### **Issue**

Closes #17 

### **Acceptance Criteria**

* **DTOs**

  * [x] `spanish/infra/dto/FlashcardCreateRequest.java` with `front` and `back` fields, both `@NotBlank`
  * [x] `spanish/infra/dto/FlashcardReviewDto.java` with `id`, `front`, `back`, and `nextReviewOn`

* **Controller**

  * [x] `FlashcardController` under `spanish/infra/`
  * [x] `@PostMapping` on `/flashcards` accepting `@Valid @RequestBody FlashcardCreateRequest` and returning `200 OK`
  * [x] `@GetMapping` on `/flashcards` that returns all flashcards as `List<FlashcardReviewDto>`
  * [x] `@GetMapping("/review")` on `/flashcards/review` that filters by `?due=true`
  * [x] Use constructor injection for `FlashcardRepository` and our `ReviewScheduler`
  * [x] Map domain `Flashcard` ↔ DTO in a private `toDto()` method

* **Validation & Clean Code**

  * [x] All incoming payloads are validated via Jakarta Bean Validation (`@NotBlank`)
  * [x] Controller methods return `ResponseEntity` with appropriate status codes

### **Notes**

* **Validation**: Added `spring-boot-starter-validation` to the POM, bringing in the Jakarta Bean Validation API and Hibernate Validator runtime so we can use `@NotBlank`, `@Valid`, etc.
* **Service Registration**: Annotated `Sm2ReviewScheduler` with `@Service` so Spring will auto-detect and inject it wherever `ReviewScheduler` is required.
