### PR TITLE
feat(weightlifting): add Exercise, Workout, WorkoutSet entities and s…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,4 @@ services:
 
 volumes:
   db_data:
+  

--- a/docs/design-diary.md
+++ b/docs/design-diary.md
@@ -21,8 +21,6 @@ The aim is to:
 
 This initial scaffolding enables a high-confidence environment for future feature development by reducing technical debt upfront.
 
----
-
 ### Lessons Learned
 
 * **Docker Basics & Containerization**
@@ -58,5 +56,30 @@ This initial scaffolding enables a high-confidence environment for future featur
   * Clear, action-based titles
   * Descriptive context
   * Bulletproof acceptance criteria using checklists
+
+---
+
+## [2025-05-27] HobbyHub API Development
+
+### Context
+
+We began by drafting a one‐page architectural sketch to clarify module boundaries (Spanish, Weightlifting, shared) and inbound/outbound flows. Next, we integrated Liquibase—adding the plugin, creating a `master.yaml` changelog, and authoring a baseline migration for our core tables. Then we built out the Spanish module in four parts: defining the `Flashcard` entity and JPA repository, implementing the SM-2 spaced-repetition algorithm as a service, exposing create/list/review endpoints with DTOs in a controller, and finally wiring everything together with comprehensive slice and integration tests plus Swagger documentation.
+
+### Lessons Learned
+
+* **Docs directory organizational power**
+  Keeping `docs/` in the repo helped crystallize design decisions, share them as an ADR substitute, and onboard collaborators.
+* **Liquibase fundamentals**
+  Learned the role of `master.yaml`, change-sets, and the `db/changelog` structure for controlled, repeatable migrations.
+* **Integration testing with Testcontainers**
+  Wrote my first real integration test against a live Postgres container, wiring in `@DynamicPropertySource` to bootstrap Spring’s `DataSource`.
+* **`java.time` mastery**
+  Leveraged `LocalDate` for review scheduling, saw how to serialize it in JSON via Jackson config.
+* **Code coverage inspection**
+  Discovered that `./mvnw clean verify` generates `target/site/jacoco/index.html`, and learned to open it in a browser to verify branch and line coverage.
+* **Slice tests demystified**
+  Understood how to write fast, focused tests with `@DataJpaTest` for JPA queries and `@WebMvcTest` (or standalone MockMvc) for controller logic.
+* **Swagger UI for endpoint verification**
+  Integrated Springdoc to expose `/swagger-ui/index.html`, making it trivial to manually explore and validate all REST endpoints.
 
 ---

--- a/src/main/java/com/andremunay/hobbyhub/spanish/app/FlashcardService.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/app/FlashcardService.java
@@ -9,18 +9,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class FlashcardService {
 
   private final FlashcardRepository repository;
   private final ReviewScheduler scheduler;
-
-  public FlashcardService(FlashcardRepository repository, ReviewScheduler scheduler) {
-    this.repository = repository;
-    this.scheduler = scheduler;
-  }
 
   /** Create and save a new flashcard. */
   public void create(String front, String back) {

--- a/src/main/java/com/andremunay/hobbyhub/spanish/domain/Flashcard.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/domain/Flashcard.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -16,6 +17,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Flashcard {
 
   @Id private UUID id;

--- a/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardController.java
+++ b/src/main/java/com/andremunay/hobbyhub/spanish/infra/FlashcardController.java
@@ -8,17 +8,15 @@ import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/flashcards")
+@RequiredArgsConstructor
 public class FlashcardController {
   private final FlashcardService flashcardService;
-
-  public FlashcardController(FlashcardService flashcardService) {
-    this.flashcardService = flashcardService;
-  }
 
   @PostMapping
   public ResponseEntity<Void> create(@Valid @RequestBody FlashcardCreateRequest req) {

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Exercise.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Exercise.java
@@ -1,0 +1,31 @@
+package com.andremunay.hobbyhub.weightlifting.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "exercises")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Exercise {
+
+  @Id
+  @Column(columnDefinition = "UUID")
+  private UUID id;
+
+  @Column(nullable = false, unique = true)
+  private String name;
+
+  @Column(name = "muscle_group, nullable=false")
+  private String muscleGroup;
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Workout.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Workout.java
@@ -1,0 +1,46 @@
+package com.andremunay.hobbyhub.weightlifting.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "workouts")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Workout {
+
+  @Id
+  @Column(columnDefinition = "UUID")
+  private UUID id;
+
+  @Column(name = "performed_on", nullable = false)
+  private LocalDate performedOn;
+
+  @OneToMany(mappedBy = "workout", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<WorkoutSet> sets = new ArrayList<>();
+
+  public Workout(UUID id, LocalDate performedOn) {
+    this.id = id;
+    this.performedOn = performedOn;
+  }
+
+  public void addSet(WorkoutSet set) {
+    sets.add(set);
+    set.setWorkout(this);
+  }
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/WorkoutSet.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/WorkoutSet.java
@@ -1,0 +1,42 @@
+package com.andremunay.hobbyhub.weightlifting.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.MapsId;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "workout_sets")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkoutSet {
+
+  @EmbeddedId private WorkoutSetId id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @MapsId("workoutId")
+  @JoinColumn(name = "workout_id")
+  private Workout workout;
+
+  @Column(name = "weight_kg", nullable = false)
+  private BigDecimal weightKg;
+
+  @Column(name = "reps", nullable = false)
+  private int reps;
+
+  public WorkoutSet(WorkoutSetId id, BigDecimal weightKg, int reps) {
+    this.id = id;
+    this.weightKg = weightKg;
+    this.reps = reps;
+  }
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/WorkoutSetId.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/WorkoutSetId.java
@@ -1,0 +1,26 @@
+package com.andremunay.hobbyhub.weightlifting.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@EqualsAndHashCode
+public class WorkoutSetId implements Serializable {
+  @Column(name = "workout_id", columnDefinition = "UUID")
+  private UUID workoutId;
+
+  @Column(name = "set_order")
+  private int order;
+}

--- a/src/main/resources/db/changelog/V3__exercise_seed.yaml
+++ b/src/main/resources/db/changelog/V3__exercise_seed.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: 3
+      author: andremunay
+      changes:
+
+        # Enable uuid-ossp extension via raw SQL
+        - sql:
+            dbms: postgresql
+            splitStatements: false
+            stripComments: true
+            sql: |
+              CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+        # Insert some common lifts
+        - insert:
+            tableName: exercises
+            columns:
+              - column: { name: id,            valueComputed: "uuid_generate_v4()" }
+              - column: { name: name,          value: "Bench Press" }
+              - column: { name: muscle_group, value: "Chest" }
+
+        - insert:
+            tableName: exercises
+            columns:
+              - column: { name: id,            valueComputed: "uuid_generate_v4()" }
+              - column: { name: name,          value: "Squat" }
+              - column: { name: muscle_group, value: "Legs" }
+
+        - insert:
+            tableName: exercises
+            columns:
+              - column: { name: id,            valueComputed: "uuid_generate_v4()" }
+              - column: { name: name,          value: "Deadlift" }
+              - column: { name: muscle_group, value: "Back" }

--- a/src/main/resources/db/changelog/V3__weightlifting_schema.yaml
+++ b/src/main/resources/db/changelog/V3__weightlifting_schema.yaml
@@ -1,0 +1,62 @@
+databaseChangeLog:
+  - changeSet:
+      id: 4
+      author: andremunay
+      changes:
+        # Remove incorrect weightlifting columns from exercises table
+        - dropColumn:
+            tableName: exercises
+            columnName: workout_id
+        - dropColumn:
+            tableName: exercises
+            columnName: sets
+        - dropColumn:
+            tableName: exercises
+            columnName: reps
+        - dropColumn:
+            tableName: exercises
+            columnName: weight_kg
+
+        # Add muscle_group column to exercises table
+        - addColumn:
+            tableName: exercises
+            columns:
+              - column:
+                  name: muscle_group
+                  type: varchar(255)
+                  defaultValue: 'General'
+                  constraints:
+                    nullable: false
+
+        # 3) Workout sets table with composite key
+        - createTable:
+            tableName: workout_sets
+            columns:
+              - column:
+                  name: workout_id
+                  type: UUID
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: set_order
+                  type: int
+                  constraints:
+                    primaryKey: true
+              - column:
+                  name: weight_kg
+                  type: decimal(5,2)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: reps
+                  type: int
+                  constraints:
+                    nullable: false
+
+        # 4) Foreign key from sets → workouts
+        - addForeignKeyConstraint:
+            baseTableName: workout_sets
+            baseColumnNames: workout_id
+            referencedTableName: workouts
+            referencedColumnNames: id
+            constraintName: fk_workout_sets_workout

--- a/src/main/resources/db/changelog/master.yaml
+++ b/src/main/resources/db/changelog/master.yaml
@@ -5,3 +5,7 @@ databaseChangeLog:
       file: db/changelog/V2__flashcard_schema.yaml
   - include:
       file: db/changelog/V2__testdata.yaml
+  - include:
+      file: db/changelog/V3__weightlifting_schema.yaml
+  - include:
+      file: db/changelog/V3__exercise_seed.yaml


### PR DESCRIPTION
---

We need to scaffold out the Weightlifting module by defining JPA domain classes for our workout data model and seeding an initial exercise catalogue via Liquibase. This includes:

1. **Domain classes** under `src/main/java/com/andremunay/hobbyhub/weightlifting/domain`:

   * `Exercise` (catalogue of lifts)
   * `Workout` (session with date and sets)
   * `WorkoutSetId` (composite key for sets)
   * `WorkoutSet` (weight/reps per set)

2. **Liquibase changelog** `V3__exercise_seed.yaml` to insert common lifts (`Bench Press`, `Squat`, `Deadlift`) using `uuid_generate_v4()`.

3. **Master changelog** (`master.yaml`) updated to include the new seed file.

---

### **Issues**

Closes #6 

### **Acceptance Criteria**

* [x] **Exercise entity** created in
  `com.andremunay.hobbyhub.weightlifting.domain.Exercise`

  * `UUID id` (PK)
  * `String name` (unique, non-null)
  * `String muscleGroup` (non-null)
* [x] **Workout entity** created in
  `...weightlifting.domain.Workout`

  * `UUID id` (PK)
  * `LocalDate performedOn` (non-null)
  * `List<WorkoutSet> sets` with `CascadeType.ALL` and orphan removal
* [x] **WorkoutSetId** embeddable created in
  `...weightlifting.domain.WorkoutSetId`

  * `UUID workoutId`
  * `int order`
  * Proper `equals`/`hashCode`
* [x] **WorkoutSet entity** created in
  `...weightlifting.domain.WorkoutSet`

  * `@EmbeddedId WorkoutSetId id`
  * `@ManyToOne` mapping to `Workout` via `@MapsId("workoutId")`
  * `BigDecimal weightKg`, `int reps`
* [x] **Liquibase seed changelog** `src/main/resources/db/changelog/V3__exercise_seed.yaml` containing inserts for:

  * Bench Press (Chest)
  * Squat (Legs)
  * Deadlift (Back)
* [x] **Master changelog** (`master.yaml`) updated to include `V3__exercise_seed.yaml` after previous change-sets
* [x] **Application startup** applies the new changelog and populates the `exercises` table (verify via `docker-compose up db` → psql or UI)
* [x] **JPA mappings verification**: saving a `Workout` with `addSet(...)` persists both workout and its sets correctly

### **Notes**
* Added `V3__weightlifting_schema.yaml` to update database
* Replaced all constructor dependency injections with Lombok `@RequiredArgsConstructor`