### PR TITLE
Added 1rm stats endpoint and weightlifting integration test

### DIFF
--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/app/WeightStatDto.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/app/WeightStatDto.java
@@ -1,0 +1,18 @@
+package com.andremunay.hobbyhub.weightlifting.app;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeightStatDto {
+  private UUID workoutId;
+  private LocalDate date;
+  private double oneRepMax;
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Exercise.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Exercise.java
@@ -26,6 +26,6 @@ public class Exercise {
   @Column(nullable = false, unique = true)
   private String name;
 
-  @Column(name = "muscle_group, nullable=false")
+  @Column(name = "muscle_group", nullable = false)
   private String muscleGroup;
 }

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/ExerciseRepository.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/ExerciseRepository.java
@@ -1,0 +1,7 @@
+package com.andremunay.hobbyhub.weightlifting.infra;
+
+import com.andremunay.hobbyhub.weightlifting.domain.Exercise;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, UUID> {}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingController.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingController.java
@@ -1,0 +1,28 @@
+package com.andremunay.hobbyhub.weightlifting.infra;
+
+import com.andremunay.hobbyhub.weightlifting.app.WeightStatDto;
+import com.andremunay.hobbyhub.weightlifting.app.WeightliftingService;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/stats")
+@RequiredArgsConstructor
+public class WeightliftingController {
+
+  private final WeightliftingService weightliftingService;
+
+  @GetMapping("/1rm/{exerciseId}")
+  public ResponseEntity<List<WeightStatDto>> getOneRepMaxStats(
+      @PathVariable UUID exerciseId, @RequestParam(defaultValue = "3") int lastN) {
+    List<WeightStatDto> stats = weightliftingService.getOneRepMaxStats(exerciseId, lastN);
+    return ResponseEntity.ok(stats);
+  }
+}

--- a/src/test/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingIntegrationTest.java
+++ b/src/test/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingIntegrationTest.java
@@ -1,0 +1,120 @@
+package com.andremunay.hobbyhub.weightlifting.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+import com.andremunay.hobbyhub.weightlifting.domain.Exercise;
+import com.andremunay.hobbyhub.weightlifting.domain.Workout;
+import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSet;
+import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSetId;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+@Import(com.andremunay.hobbyhub.TestcontainersConfiguration.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Testcontainers
+class WeightliftingIntegrationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  @Autowired private ExerciseRepository exerciseRepo;
+
+  @Autowired private WorkoutRepository workoutRepo;
+
+  private UUID exerciseId;
+
+  @BeforeEach
+  void setUp() {
+    // 1) Create one Exercise in DB
+    Exercise exercise = new Exercise(UUID.randomUUID(), "Bench Press", "Chest");
+    exerciseRepo.save(exercise);
+    this.exerciseId = exercise.getId();
+
+    // 2) Create 3 Workouts on consecutive days, each with one WorkoutSet for that Exercise
+    Workout w1 = new Workout(UUID.randomUUID(), LocalDate.of(2025, 5, 1));
+    Workout w2 = new Workout(UUID.randomUUID(), LocalDate.of(2025, 5, 2));
+    Workout w3 = new Workout(UUID.randomUUID(), LocalDate.of(2025, 5, 3));
+
+    // Persist these workouts first so that they have an ID
+    workoutRepo.saveAll(List.of(w1, w2, w3));
+
+    // Now add one WorkoutSet to each, with strictly increasing weight
+    WorkoutSet s1 =
+        new WorkoutSet(new WorkoutSetId(w1.getId(), 1), exercise, BigDecimal.valueOf(50), 5);
+    s1.setWorkout(w1);
+
+    WorkoutSet s2 =
+        new WorkoutSet(new WorkoutSetId(w2.getId(), 1), exercise, BigDecimal.valueOf(60), 5);
+    s2.setWorkout(w2);
+
+    WorkoutSet s3 =
+        new WorkoutSet(new WorkoutSetId(w3.getId(), 1), exercise, BigDecimal.valueOf(70), 5);
+    s3.setWorkout(w3);
+
+    // Save all sets by saving the owning Workout (cascade = ALL)
+    w1.addSet(s1);
+    w2.addSet(s2);
+    w3.addSet(s3);
+
+    // Persist changes
+    workoutRepo.saveAll(List.of(w1, w2, w3));
+  }
+
+  @Test
+  void getOneRepMaxStats_returnsAscendingDatesAndCorrectValues() {
+    // Hit the endpoint: GET /stats/1rm/{exerciseId}?lastN=3
+    String url = "http://localhost:" + port + "/stats/1rm/" + exerciseId + "?lastN=3";
+
+    ResponseEntity<List<WeightStat>> response =
+        restTemplate.exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<>() {});
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    List<WeightStat> body = response.getBody();
+    assertThat(body).isNotNull().hasSize(3);
+
+    // The JSON should be sorted by date ascending: [2025-05-01, 2025-05-02, 2025-05-03]
+    assertThat(body.get(0).getDate()).isEqualTo(LocalDate.of(2025, 5, 1));
+    assertThat(body.get(1).getDate()).isEqualTo(LocalDate.of(2025, 5, 2));
+    assertThat(body.get(2).getDate()).isEqualTo(LocalDate.of(2025, 5, 3));
+
+    // Epley 1RM formula: for weight=50, reps=5 → 50 * (1 + 5/30) = 58.3333…
+    // for 60 & 5 → 60 * (1 + 5/30) = 69.9999…, for 70 & 5 → 81.6666…
+    double rm1 = body.get(0).getOneRepMax();
+    double rm2 = body.get(1).getOneRepMax();
+    double rm3 = body.get(2).getOneRepMax();
+
+    assertThat(rm1).isCloseTo(58.3333, within(1e-3));
+    assertThat(rm2).isCloseTo(70.0000, within(1e-3));
+    assertThat(rm3).isCloseTo(81.6667, within(1e-3));
+  }
+
+  // Helper class to map JSON response (the field names must match WeightStatDto)
+  @Getter
+  @Setter
+  @NoArgsConstructor
+  public static class WeightStat {
+    private UUID workoutId;
+    private LocalDate date;
+    private double oneRepMax;
+  }
+}


### PR DESCRIPTION
We want to support a new feature that computes one‐repetition‐max (“1RM”) statistics for a given exercise and exposes them via a REST endpoint. This involves three main tasks:

1. **Extend `WorkoutRepository`**
   Add a JPQL query method `findSetsByExerciseId(UUID exerciseId, Pageable pageable)` that returns the most recent WorkoutSet rows (joining back to the parent Workout to retrieve its `performedOn` date). We will page this query so that only the last *N* sets are returned.

2. **Expose a “1RM‐Stats” endpoint**

   * Create a DTO (`WeightStatDto`) containing `{ workoutId, date, oneRepMax }`.
   * In `WeightliftingService`, implement `getOneRepMaxStats(UUID exerciseId, int lastN)` which:

     1. Uses `findSetsByExerciseId(exerciseId, PageRequest.of(0, lastN))` to fetch the most recent *N* WorkoutSet rows.
     2. Groups those rows by `Workout.id` and picks the single highest‐weight set per workout.
     3. Sorts the resulting “top sets” by their parent `Workout.performedOn` in **ascending** order.
     4. For each sorted set, calls the injected `OneRepMaxStrategy` (e.g. Epley) to compute the 1RM and returns a `WeightStatDto` containing `{ workoutId, date, oneRepMax }`.
   * Add a new controller method in `WeightliftingController` at `GET /stats/1rm/{exerciseId}?lastN={N}` that invokes `WeightliftingService#getOneRepMaxStats(...)` and returns a JSON array of `WeightStatDto` objects (sorted by date ascending).

3. **Write an end-to-end integration test with Testcontainers**

   * Launch a PostgreSQL container using Testcontainers.
   * Override Spring Boot’s datasource properties so that the application context points at that container.
   * Create and save one `Exercise` record.
   * Create three `Workout` entities on consecutive dates (e.g. 2025-05-01, 2025-05-02, 2025-05-03), each with a single `WorkoutSet` (for the same exercise) at strictly increasing weights (e.g. 50, 60, 70 kg at 5 reps).
   * Call `GET /stats/1rm/{exerciseId}?lastN=3` via `TestRestTemplate`.
   * Assert that the returned JSON array:

     * Has exactly three entries.
     * Is sorted by `date` ascending (2025-05-01 → 2025-05-02 → 2025-05-03).
     * Each `oneRepMax` value matches the Epley 1RM calculation (e.g. 50×(1+5/30)=58.3333…, 60×(1+5/30)=70.0000, 70×(1+5/30)=81.6667).

---

### **Issue**

Closes #8 

### **Acceptance Criteria**

* [x] **Repository Query**

  * [x] Add a method in `WorkoutRepository`, e.g.:

    ```
    findSetsByExerciseId(UUID exerciseId, Pageable pageable)
    // JPQL: select ws from WorkoutSet ws join ws.workout w
    //      where ws.exercise.id = :exerciseId
    //      order by w.performedOn desc
    ```
  * [x] Verify (unit or slice test) that passing `PageRequest.of(0, lastN)` returns exactly the most recent N `WorkoutSet` records, ordered by `performedOn` descending.

* [x] **DTO & Service Logic**

  * [x] Create a `WeightStatDto` (fields: `UUID workoutId`, `LocalDate date`, `double oneRepMax`).
  * [x] Implement `WeightliftingService.getOneRepMaxStats(UUID exerciseId, int lastN)` to:

    1. Call `findSetsByExerciseId(exerciseId, PageRequest.of(0, lastN))`.
    2. Group returned `WorkoutSet` objects by `workout.id`, select the set with the highest `weightKg` per workout.
    3. Sort those top-set entries by `workout.performedOn` ascending.
    4. For each sorted set, compute `oneRepMax = ormStrategy.calculate(weight, reps)` and return a `WeightStatDto`.
  * [x] Add a unit (or service-slice) test that:

    * Mocks the repository to return a known list of `WorkoutSet` (with known dates, weights, reps).
    * Asserts that the returned `List<WeightStatDto>` is in ascending date order.
    * Asserts that each `oneRepMax` equals the expected Epley result (within \~1e-3).

* [x] **Controller Endpoint**

  * [x] Add a `@RestController` (e.g. `WeightliftingController`) with a handler for

    ```
    GET /stats/1rm/{exerciseId}?lastN={n}
    → returns List<WeightStatDto> as JSON
    ```
  * [x] (Optional) Add a controller slice test (`@WebMvcTest`) that mocks the service and verifies JSON field names (`workoutId`, `date`, `oneRepMax`) and HTTP 200 status.

* [x] **Integration Test (Testcontainers)**

  * [x] Create `WeightliftingIntegrationTest` with `@SpringBootTest(webEnvironment=RANDOM_PORT)` and `@Testcontainers`.
  * [x] Define a static `PostgreSQLContainer<?>` and override Spring’s datasource via `@DynamicPropertySource` (JDBC URL, username, password, set `ddl-auto=update`).
  * [x] In `@BeforeEach`:

    1. Save one `Exercise` to the DB.
    2. Create and save three `Workout` entities on consecutive dates (e.g., 2025-05-01, 2025-05-02, 2025-05-03).
    3. For each workout, create exactly one `WorkoutSet` tied to that exercise, with strictly increasing `weightKg` (50→60→70 at 5 reps), associate to the workout, and save.
  * [x] Write a test that:

    1. Uses `TestRestTemplate` to `GET /stats/1rm/{exerciseId}?lastN=3`.
    2. Asserts HTTP 200.
    3. Parses the response into a helper class matching `WeightStatDto` fields.
    4. Asserts the list size is 3.
    5. Verifies that `date` values are `[2025-05-01, 2025-05-02, 2025-05-03]` (ascending).
    6. Verifies that the computed `oneRepMax` values match Epley:

       * 50 kg @ 5 reps → 58.3333…
       * 60 kg @ 5 reps → 70.0000…
       * 70 kg @ 5 reps → 81.6667…
         (all within a small epsilon, e.g. 1e-3)

### **Notes**
* Fixed bug in `Exercise` field `muscleGroup`