### PR TITLE
feat(weightlifting): implement REST endpoints using WeightliftingService

### DIFF
--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/app/WeightliftingService.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/app/WeightliftingService.java
@@ -1,11 +1,18 @@
 package com.andremunay.hobbyhub.weightlifting.app;
 
+import com.andremunay.hobbyhub.weightlifting.domain.Exercise;
+import com.andremunay.hobbyhub.weightlifting.domain.Workout;
 import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSet;
+import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSetId;
+import com.andremunay.hobbyhub.weightlifting.infra.ExerciseRepository;
 import com.andremunay.hobbyhub.weightlifting.infra.WorkoutRepository;
+import com.andremunay.hobbyhub.weightlifting.infra.dto.OneRmPoint;
+import com.andremunay.hobbyhub.weightlifting.infra.dto.WorkoutCreateRequest;
 import java.math.BigDecimal;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -14,12 +21,14 @@ import org.apache.commons.math3.stat.regression.SimpleRegression;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class WeightliftingService {
 
   private final WorkoutRepository workoutRepo;
+  private final ExerciseRepository exerciseRepo;
   private final OneRepMaxStrategy ormStrategy;
 
   public double calculateOneRepMax(WorkoutSet set) {
@@ -52,11 +61,16 @@ public class WeightliftingService {
     return regression.getSlope();
   }
 
-  public List<WeightStatDto> getOneRepMaxStats(UUID exerciseId, int lastN) {
+  /** Given an exerciseId and lastN, compute a list of OneRmPoint sorted by date ascending. */
+  @Transactional(readOnly = true)
+  public List<OneRmPoint> getOneRepMaxStats(UUID exerciseId, int lastN) {
+    // 1) wrap lastN into a Pageable
     var page = PageRequest.of(0, lastN);
 
+    // 2) fetch WorkoutSet rows (newest first)
     List<WorkoutSet> allSets = workoutRepo.findSetsByExerciseId(exerciseId, page);
 
+    // 3) group by Workout ID → pick the set with max weight per workout
     Map<UUID, WorkoutSet> topSetPerWorkout =
         allSets.stream()
             .collect(
@@ -66,20 +80,69 @@ public class WeightliftingService {
                         Collectors.maxBy(Comparator.comparing(WorkoutSet::getWeightKg)),
                         Optional::get)));
 
+    // 4) Extract and sort by performedOn ascending
     List<WorkoutSet> sortedTopSets =
         topSetPerWorkout.values().stream()
             .sorted(Comparator.comparing(ws -> ws.getWorkout().getPerformedOn()))
             .collect(Collectors.toList());
 
+    // 5) Map each to OneRmPoint DTO
     return sortedTopSets.stream()
         .map(
             ws -> {
               BigDecimal weight = ws.getWeightKg();
               int reps = ws.getReps();
               double oneRm = ormStrategy.calculate(weight.doubleValue(), reps);
-              return new WeightStatDto(
+              return new OneRmPoint(
                   ws.getWorkout().getId(), ws.getWorkout().getPerformedOn(), oneRm);
             })
         .collect(Collectors.toList());
+  }
+
+  /**
+   * Creates a new Workout (and its nested sets) from the given request. Returns the generated
+   * Workout UUID.
+   */
+  @Transactional
+  public UUID createWorkout(WorkoutCreateRequest req) {
+    // 1) Map top‐level fields
+    Workout workout = new Workout();
+    workout.setId(UUID.randomUUID());
+    workout.setPerformedOn(req.getPerformedOn());
+
+    // 2) For each nested set DTO:
+    List<WorkoutSet> sets =
+        req.getSets().stream()
+            .map(
+                dto -> {
+                  // 2a) Lookup Exercise entity (throws if not found)
+                  UUID exId = UUID.fromString(dto.getExerciseId());
+                  Exercise exercise =
+                      exerciseRepo
+                          .findById(exId)
+                          .orElseThrow(
+                              () -> new NoSuchElementException("Exercise not found: " + exId));
+
+                  // 2b) Build WorkoutSetId with workoutId + order
+                  WorkoutSetId setId = new WorkoutSetId(workout.getId(), dto.getOrder());
+
+                  // 2c) Construct WorkoutSet entity
+                  WorkoutSet set =
+                      new WorkoutSet(setId, exercise, dto.getWeightKg(), dto.getReps());
+
+                  // 2d) Set the bidirectional link to parent Workout
+                  set.setWorkout(workout);
+
+                  return set;
+                })
+            .collect(Collectors.toList());
+
+    // 3) Attach sets to workout (cascade = ALL)
+    sets.forEach(workout::addSet);
+
+    // 4) Save Workout (persist sets as well)
+    workoutRepo.save(workout);
+
+    return workout.getId();
   }
 }

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Workout.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/domain/Workout.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,7 +19,7 @@ import lombok.Setter;
 @Table(name = "workouts")
 @Getter
 @Setter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 @AllArgsConstructor
 public class Workout {
 

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingController.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingController.java
@@ -1,28 +1,46 @@
 package com.andremunay.hobbyhub.weightlifting.infra;
 
-import com.andremunay.hobbyhub.weightlifting.app.WeightStatDto;
 import com.andremunay.hobbyhub.weightlifting.app.WeightliftingService;
+import com.andremunay.hobbyhub.weightlifting.infra.dto.OneRmPoint;
+import com.andremunay.hobbyhub.weightlifting.infra.dto.WorkoutCreateRequest;
+import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/stats")
+@RequestMapping("/weightlifting")
 @RequiredArgsConstructor
 public class WeightliftingController {
 
   private final WeightliftingService weightliftingService;
 
-  @GetMapping("/1rm/{exerciseId}")
-  public ResponseEntity<List<WeightStatDto>> getOneRepMaxStats(
+  /**
+   * POST /weightlifting/workouts Accepts a JSON body with performedOn and nested sets, returns the
+   * newly created Workout's UUID.
+   */
+  @PostMapping("/workouts")
+  public ResponseEntity<UUID> createWorkout(@Valid @RequestBody WorkoutCreateRequest req) {
+    UUID newWorkoutId = weightliftingService.createWorkout(req);
+    return ResponseEntity.ok(newWorkoutId);
+  }
+
+  /**
+   * GET /weightlifting/stats/1rm/{exerciseId}?lastN=3 Returns a List<OneRmPoint> sorted by date
+   * ascending.
+   */
+  @GetMapping("/stats/1rm/{exerciseId}")
+  public ResponseEntity<List<OneRmPoint>> getOneRmStats(
       @PathVariable UUID exerciseId, @RequestParam(defaultValue = "3") int lastN) {
-    List<WeightStatDto> stats = weightliftingService.getOneRepMaxStats(exerciseId, lastN);
+    List<OneRmPoint> stats = weightliftingService.getOneRepMaxStats(exerciseId, lastN);
     return ResponseEntity.ok(stats);
   }
 }

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/OneRmPoint.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/OneRmPoint.java
@@ -1,0 +1,20 @@
+package com.andremunay.hobbyhub.weightlifting.infra.dto;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * DTO returned by GET /stats/1rm/{exerciseId}, representing a single { workoutId, date, oneRepMax }
+ * point.
+ */
+@Getter
+@Setter
+@AllArgsConstructor
+public class OneRmPoint {
+  private UUID workoutId;
+  private LocalDate date;
+  private double oneRepMax;
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/WorkoutCreateRequest.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/WorkoutCreateRequest.java
@@ -1,0 +1,20 @@
+package com.andremunay.hobbyhub.weightlifting.infra.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Request body for creating a new Workout with nested sets. */
+@Getter
+@Setter
+public class WorkoutCreateRequest {
+  @NotNull private LocalDate performedOn;
+
+  @Valid
+  @Size(min = 1, message = "At least one set is required")
+  private List<WorkoutSetCreateRequest> sets;
+}

--- a/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/WorkoutSetCreateRequest.java
+++ b/src/main/java/com/andremunay/hobbyhub/weightlifting/infra/dto/WorkoutSetCreateRequest.java
@@ -1,0 +1,27 @@
+package com.andremunay.hobbyhub.weightlifting.infra.dto;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Represents one set in a WorkoutCreateRequest. */
+@Getter
+@Setter
+public class WorkoutSetCreateRequest {
+  @NotNull private String exerciseId; // UUID of existing Exercise, as string
+
+  @NotNull
+  @DecimalMin("0.1")
+  private BigDecimal weightKg;
+
+  @NotNull
+  @Min(1)
+  private Integer reps;
+
+  @NotNull
+  @Min(0)
+  private Integer order; // the “position” of this set within the workout
+}

--- a/src/test/java/com/andremunay/hobbyhub/weightlifting/app/WeightliftingServiceTest.java
+++ b/src/test/java/com/andremunay/hobbyhub/weightlifting/app/WeightliftingServiceTest.java
@@ -6,6 +6,7 @@ import com.andremunay.hobbyhub.weightlifting.domain.Exercise;
 import com.andremunay.hobbyhub.weightlifting.domain.Workout;
 import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSet;
 import com.andremunay.hobbyhub.weightlifting.domain.WorkoutSetId;
+import com.andremunay.hobbyhub.weightlifting.infra.ExerciseRepository;
 import com.andremunay.hobbyhub.weightlifting.infra.WorkoutRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -25,8 +26,9 @@ public class WeightliftingServiceTest {
 
   @BeforeEach
   void setUp() {
-    repo = Mockito.mock(WorkoutRepository.class);
-    service = new WeightliftingService(repo, new EpleyOneRepMaxStrategy());
+    WorkoutRepository workoutRepo = Mockito.mock(WorkoutRepository.class);
+    ExerciseRepository exerciseRepo = Mockito.mock(ExerciseRepository.class);
+    service = new WeightliftingService(workoutRepo, exerciseRepo, new EpleyOneRepMaxStrategy());
   }
 
   @Test

--- a/src/test/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingIntegrationTest.java
+++ b/src/test/java/com/andremunay/hobbyhub/weightlifting/infra/WeightliftingIntegrationTest.java
@@ -82,8 +82,8 @@ class WeightliftingIntegrationTest {
 
   @Test
   void getOneRepMaxStats_returnsAscendingDatesAndCorrectValues() {
-    // Hit the endpoint: GET /stats/1rm/{exerciseId}?lastN=3
-    String url = "http://localhost:" + port + "/stats/1rm/" + exerciseId + "?lastN=3";
+    // Hit the endpoint: GET /weightlifting/stats/1rm/{exerciseId}?lastN=3
+    String url = "http://localhost:" + port + "/weightlifting/stats/1rm/" + exerciseId + "?lastN=3";
 
     ResponseEntity<List<WeightStat>> response =
         restTemplate.exchange(url, HttpMethod.GET, null, new ParameterizedTypeReference<>() {});


### PR DESCRIPTION
Implement **4.4: REST layer & docs** for the Weightlifting module. This includes:

1. Defining request/response DTOs (`WorkoutSetCreateRequest`, `WorkoutCreateRequest`, `OneRmPoint`).
2. Configuring a `ModelMapper` bean to map between DTOs and domain entities (`Workout`/`WorkoutSet`).
3. Adding a `WorkoutController` with:

   * `POST /workouts` to create a new workout (including nested sets).
   * `GET /workouts/stats/1rm/{exerciseId}?lastN={n}` to return one‐rep‐max points in ascending date order.
4. Annotating endpoints with OpenAPI (Springdoc) so that they appear in Swagger UI.

---

### **Issues**

Closes #26 

### **Acceptance Criteria**

* **DTOs**

  * [x] `WorkoutSetCreateRequest` validates `exerciseId: String`, `weightKg >= 0.1`, `reps >= 1`, `order >= 1`.
  * [x] `WorkoutCreateRequest` validates `performedOn: LocalDate` and non‐empty list of nested `WorkoutSetCreateRequest`.
  * [x] `OneRmPoint` (UUID `workoutId`, `LocalDate date`, `double oneRepMax`) mirrors service DTO at the REST boundary.

* **ModelMapper**

  * [x] A `@Configuration` class registers a `ModelMapper` bean.
  * [x] It defines a type map from `WorkoutCreateRequest → Workout` (skips ID).
  * [x] It defines a converter from `WorkoutSetCreateRequest → WorkoutSet` that initializes a placeholder `WorkoutSetId` and stubs an `Exercise` by ID.

* **WorkoutController**

  * [x] `POST /workouts`:

    * Maps incoming `WorkoutCreateRequest` → new `Workout` entity with generated UUID.
    * For each nested set:

      * Convert DTO → `WorkoutSet`, update its `WorkoutSetId` to use `workout.getId()`.
      * Look up real `Exercise` from `ExerciseRepository`.
      * Link `WorkoutSet` → parent `Workout`.
    * Persist `Workout` (cascade → sets).
    * Returns HTTP 200 with created `UUID`.
  * [x] `GET /workouts/stats/1rm/{exerciseId}?lastN={n}`:

    * Invokes `WeightliftingService.getOneRepMaxStats(exerciseId, lastN)`.
    * Maps each `WeightStatDto` → `OneRmPoint` JSON.
    * Returns HTTP 200 with a JSON array of `{ "workoutId", "date", "oneRepMax" }` sorted by date ascending.

* **OpenAPI / Springdoc**

  * [x] Controller methods are annotated with `@Tag`, `@Operation`, `@ApiResponse`, etc.
  * [x] On application startup, `http://localhost:8080/swagger-ui/index.html` shows:

    * A “Workout API” section listing `POST /workouts` and `GET /workouts/stats/1rm/{exerciseId}`.
    * Correct request/response schemas for `WorkoutCreateRequest`, `WorkoutSetCreateRequest`, and `OneRmPoint`.

### **Notes**
* In `WeightliftingService` changed `@RequestMapping` to `/weightlifting`