### PR TITLE
feat(logging): enable structured JSON logs with Logback JsonLayout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ HELP.md
 .factorypath
 .springBeans
 .sts4-cache
+*.sh
 
 # Spring Boot secrets/config
 

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Dlogback.statusListenerClass=ch.qos.logback.core.status.NopStatusListener

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+./mvnw spotless:apply
+./mvnw clean verify 2>&1 | tee build.log

--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,21 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
 			<artifactId>jackson-datatype-jsr310</artifactId>
-			<version>2.19.0</version>
 		</dependency>
 		<dependency>
 			<groupId>io.github.cdimascio</groupId>
 			<artifactId>dotenv-java</artifactId>
 			<version>3.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-json-classic</artifactId>
+			<version>0.1.5</version>
+		</dependency>		
+		<dependency>
+			<groupId>ch.qos.logback.contrib</groupId>
+			<artifactId>logback-jackson</artifactId>
+			<version>0.1.5</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+# Clear or create log file
+: > out.log
+
+# Run Maven, log to file, pipe JSON lines to jq
+./mvnw -q clean spring-boot:run 2>&1 | tee out.log | jq .

--- a/src/main/java/com/andremunay/hobbyhub/HobbyhubApplication.java
+++ b/src/main/java/com/andremunay/hobbyhub/HobbyhubApplication.java
@@ -1,9 +1,11 @@
 package com.andremunay.hobbyhub;
 
 import io.github.cdimascio.dotenv.Dotenv;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
+@Slf4j
 @SpringBootApplication
 public class HobbyhubApplication {
 

--- a/src/main/java/com/andremunay/hobbyhub/logging/UserContextFilter.java
+++ b/src/main/java/com/andremunay/hobbyhub/logging/UserContextFilter.java
@@ -1,0 +1,46 @@
+package com.andremunay.hobbyhub.logging;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class UserContextFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
+      throws ServletException, IOException {
+
+    try {
+      // Set requestId
+      MDC.put("requestId", UUID.randomUUID().toString());
+
+      // Set user if authenticated
+      Authentication auth = (Authentication) request.getUserPrincipal();
+      if (auth instanceof OAuth2AuthenticationToken token) {
+        OAuth2User user = token.getPrincipal();
+        String githubLogin = user.getAttribute("login");
+        if (githubLogin != null) {
+          MDC.put("user", githubLogin);
+        }
+      }
+
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.clear();
+    }
+  }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,9 @@ spring:
             client-secret: ${OAUTH_CLIENT_SECRET}
             scope: repo,read:user
 
+  main:
+    banner-mode: "off"
+
   # --- Liquibase ---
   liquibase:
     enabled: true
@@ -37,7 +40,3 @@ flyio:
 registry:
   username: ${REGISTRY_USERNAME}
   password: ${REGISTRY_PASSWORD}
-
-logging:
-  level:
-    org.springframework.security: DEBUG

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,18 @@
+<configuration>
+
+  <!-- Console appender that emits JSON to STDOUT -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+      <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
+        <jsonFormatter class="ch.qos.logback.contrib.jackson.JacksonJsonFormatter"/>
+        <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSXXX</timestampFormat>
+      </layout>
+    </encoder>
+  </appender>
+
+  <!-- Root logger config: everything INFO and above goes to STDOUT -->
+  <root level="INFO">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
Enable structured JSON log output using `logback-json-classic` so that all application logs are valid JSON. This simplifies parsing with tools like `jq` and improves log ingestion in downstream observability platforms (e.g., Datadog, ELK, CloudWatch).

---

### **Issue**

Closes #34 

### **Acceptance Criteria**

* [x] `logback-json-classic` dependency is added to `pom.xml`
* [x] A `logback.xml` file is created under `src/main/resources/`
* [x] `ConsoleAppender` is configured to use `JsonLayout` with:

  * [x] `JacksonJsonFormatter`
  * [x] `ISO8601` timestamps
* [x] Root logger is set to `INFO` and outputs to `STDOUT`
* [x] Logs are verified as valid JSON by running:

  ```bash
  ./mvnw -q spring-boot:run | jq .
  ```

### **Notes**

* Disabled spring banner - interfering with `jq`
* Unsure if Mdc is enabled by default, will come back to later down the line