### PR TITLE
feat(devops): modify dockerfile and docker-compose for full-stack demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.war
 *.log
 !.mvn/wrapper/maven-wrapper.jar
+*.sh
 
 # Optional Spring Init file
 HELP.md
@@ -22,7 +23,6 @@ HELP.md
 .factorypath
 .springBeans
 .sts4-cache
-*.sh
 
 # Spring Boot secrets/config
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,6 @@ services:
     build: .
     ports:
       - "8080:8080"
-    environment:
-      - SPRING_PROFILES_ACTIVE=prod
     env_file:
       - .env
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,16 @@
-# Use a JDK image
-FROM openjdk:21-jdk-slim
+# 1) Build stage: compile & package with JDK
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /app
+# Copy everything (including mvnw & .mvn)
+COPY . .
+# Build the jar, skipping tests (to speed up demo builds)
+RUN ./mvnw -B package -DskipTests
 
-# Add the JAR file (you'll need to build it first)
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
-
-# Run the app
+# 2) Run stage: slim runtime image with just the JRE
+FROM eclipse-temurin:21-jre
+# Allow overriding the JAR via build-arg if desired
+ARG JAR_FILE=target/*-SNAPSHOT.jar
+# Copy the built jar from the builder stage
+COPY --from=builder /app/${JAR_FILE} app.jar
+# Default entrypoint
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Add a multi-stage Dockerfile and a top-level `docker-compose.yml` to run the full HobbyHub API stack locally with Postgres and Prometheus. Enables one-command startup for API, DB, and metrics dashboard — great for onboarding and showcasing the project.

---

### **Issue**

Closes #38 

### **Acceptance Criteria**

* [x] `Dockerfile` uses multi-stage build:

  * [x] First stage compiles the app with Maven
  * [x] Second stage runs the jar using a slim JRE
* [x] `docker-compose.yml` defines three services:

  * [x] `db`: Postgres 16 with `POSTGRES_USER`, `PASSWORD`, and `DB` set
  * [x] `api`: builds from Dockerfile, exposes port 8080, depends on `db`
  * [x] `prometheus`: mounts `./ops/prometheus.yml`, exposes port 9090
* [x] Prometheus successfully scrapes from `/actuator/prometheus`
* [x] `.env` file is supported for secrets (`OAUTH_CLIENT_ID`, etc.)
* [x] Docker build and compose commands succeed:

  ```bash
  docker compose up --build
  ```
* [x] Verify:

  * [x] `http://localhost:8080/actuator/prometheus` returns metrics
  * [x] `http://localhost:9090` loads Prometheus UI
  * [x] Metrics like `jvm_memory_used_bytes` are available
