### PR TITLE
add readiness health check for fly deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,15 @@ services:
 
   api:
     build: .
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - JAVA_OPTS=
     ports:
       - "8080:8080"
     env_file:
       - .env
+    depends_on:
+      - db
 
   prometheus:
     image: prom/prometheus:latest

--- a/fly.toml
+++ b/fly.toml
@@ -6,6 +6,8 @@ primary_region = "sea"
 
 [env]
   PORT = "8080"
+  SPRING_PROFILES_ACTIVE = "fly"
+  JAVA_OPTS = "-Xmx300m -Xms64m"
 
 [vm]
   memory = 1024
@@ -36,3 +38,12 @@ primary_region = "sea"
     method = "GET"
     path = "/actuator/health"
     protocol = "http"
+
+  [[services.checks]]
+    type = "http"
+    interval = "10s"
+    timeout = "5s"
+    method = "GET"
+    path = "/actuator/health?group=readiness"
+    protocol = "http"
+    tls_skip_verify = false

--- a/src/main/java/com/andremunay/hobbyhub/HomeController.java
+++ b/src/main/java/com/andremunay/hobbyhub/HomeController.java
@@ -10,6 +10,7 @@ public class HomeController {
 
   @GetMapping("/welcome")
   public String welcome(@AuthenticationPrincipal OAuth2User principal) {
-    return "Welcome, " + principal.getAttribute("login");
+    String name = (principal != null) ? principal.getAttribute("name") : "Guest";
+    return "Welcome, " + name;
   }
 }

--- a/src/main/java/com/andremunay/hobbyhub/shared/config/LocalSecurityConfig.java
+++ b/src/main/java/com/andremunay/hobbyhub/shared/config/LocalSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.andremunay.hobbyhub.shared.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Profile("local")
+@Configuration
+public class LocalSecurityConfig {
+
+  @Bean
+  public SecurityFilterChain localFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(
+                        "/actuator/**",
+                        "/login/**",
+                        "/oauth2/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/swagger-ui.html",
+                        "/actuator/prometheus")
+                    .permitAll()
+                    .anyRequest()
+                    .permitAll())
+        .csrf(csrf -> csrf.disable());
+
+    return http.build();
+  }
+}

--- a/src/main/java/com/andremunay/hobbyhub/shared/config/SecurityConfig.java
+++ b/src/main/java/com/andremunay/hobbyhub/shared/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.andremunay.hobbyhub.shared.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.lang.NonNull;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
@@ -10,6 +11,7 @@ import org.springframework.security.web.authentication.LoginUrlAuthenticationEnt
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Profile("fly")
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {

--- a/src/main/resources/application-fly.yaml
+++ b/src/main/resources/application-fly.yaml
@@ -45,10 +45,38 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info,metrics, prometheus
+        include:
+          - health
+          - info
+          - metrics
+          - prometheus
   endpoint:
     prometheus:
       enabled: true
-  metrics:
-    tags:
-      application: hobbyhub-api
+    health:
+      show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include:
+            - db
+    metrics:
+      tags:
+        application: hobbyhub-api
+
+  health:
+    db:
+      enabled: true
+    readiness:
+      enabled: true
+      include:
+        - db
+    liveness:
+      enabled: true
+      include:
+        - none
+
+logging:
+  level:
+    root: INFO

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,81 @@
+spring:
+  config:
+    import: "optional:dotenv:.env"
+
+  application:
+    name: hobbyhub
+
+  security:
+    oauth2:
+      client:
+        registration:
+          github:
+            client-id: dummy
+            client-secret: dummy
+    enabled: false
+
+  main:
+    banner-mode: "off"
+  jpa:
+    open-in-view: false
+
+  # --- Liquibase ---
+  liquibase:
+    enabled: true
+    change-log: classpath:db/changelog/master.yaml
+
+  datasource:
+    url: jdbc:postgresql://db:5432/${POSTGRES_DB}
+    username: ${POSTGRES_USER}
+    password: ${POSTGRES_PASSWORD}
+    driver-class-name: org.postgresql.Driver
+
+server:
+  address: 0.0.0.0
+  port: 8080
+
+# --- Secrets & Configuration ---
+github:
+  oauth:
+    client-id: ${OAUTH_CLIENT_ID}    # injected via GitHub Actions
+    client-secret: ${OAUTH_CLIENT_SECRET}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - metrics
+          - prometheus
+  endpoint:
+    prometheus:
+      enabled: true
+    health:
+      show-details: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include:
+            - db
+    metrics:
+      tags:
+        application: hobbyhub-api
+
+  health:
+    db:
+      enabled: true
+    readiness:
+      enabled: true
+      include:
+        - db
+    liveness:
+      enabled: true
+      include:
+        - none
+
+logging:
+  level:
+    root: DEBUG

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: local


### PR DESCRIPTION
To prevent Fly.io from routing traffic to a machine before it has completed startup tasks (e.g., Liquibase migrations), a readiness probe should be added using Spring Boot’s `/actuator/health?group=readiness` endpoint. This ensures the app only receives requests when fully ready.

---

### **Issue**

Closes #45 

### **Acceptance Criteria**

* [x] Spring Boot exposes `/actuator/health?group=readiness` and includes key indicators (e.g., database)
* [x] `application.yaml` enables actuator probes and readiness group
* [x] `fly.toml` defines a Fly.io HTTP check using the readiness probe
* [x] Readiness probe passes successfully on deploy
* [x] New machines only receive traffic after readiness check is healthy

### **Notes**

* Separated `application.yaml` into 2 profiles (local and fly)
