### PR TITLE
replace /welcome with tailwind powered link hub

### DIFF
--- a/src/main/java/com/andremunay/hobbyhub/HomeController.java
+++ b/src/main/java/com/andremunay/hobbyhub/HomeController.java
@@ -1,7 +1,6 @@
 package com.andremunay.hobbyhub;
 
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,8 +8,35 @@ import org.springframework.web.bind.annotation.RestController;
 public class HomeController {
 
   @GetMapping("/welcome")
-  public String welcome(@AuthenticationPrincipal OAuth2User principal) {
-    String name = (principal != null) ? principal.getAttribute("name") : "Guest";
-    return "Welcome, " + name;
+  public ResponseEntity<String> welcomePage() {
+    String html =
+        """
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>HobbyHub API - Welcome</title>
+        <script src="https://cdn.tailwindcss.com"></script>
+      </head>
+      <body class="bg-gray-50 text-gray-900 font-sans">
+        <div class="max-w-3xl mx-auto py-12 px-4">
+          <h1 class="text-3xl font-bold mb-6">Welcome to HobbyHub API</h1>
+          <p class="mb-4">Explore tools and diagnostics:</p>
+
+          <div class="grid gap-4">
+            <a href="/swagger-ui/index.html" class="text-blue-600 hover:underline">Swagger UI</a>
+
+            <h2 class="text-xl font-semibold mt-6">Ops</h2>
+            <a href="/actuator/metrics" class="text-blue-600 hover:underline">Actuator Metrics</a>
+            <a href="/actuator/prometheus" class="text-blue-600 hover:underline">Prometheus Scrape</a>
+            <a href="https://hobbyhub-prometheus.fly.dev" class="text-blue-600 hover:underline" target="_blank">Prometheus Dashboard</a>
+          </div>
+        </div>
+      </body>
+      </html>
+      """;
+
+    return ResponseEntity.ok().header("Content-Type", "text/html").body(html);
   }
 }

--- a/src/test/java/com/andremunay/hobbyhub/SecurityIntegrationTest.java
+++ b/src/test/java/com/andremunay/hobbyhub/SecurityIntegrationTest.java
@@ -62,19 +62,18 @@ class SecurityIntegrationTest {
   void whenAuthenticated_thenAccessWelcomePage() throws Exception {
     Map<String, Object> attributes = Map.of("name", "Test User");
 
-    var principal =
-        new DefaultOAuth2User(
-            List.of(() -> "ROLE_USER"),
-            attributes,
-            "name" // This must match the attribute used to extract the principal name
-            );
+    var principal = new DefaultOAuth2User(List.of(() -> "ROLE_USER"), attributes, "name");
 
     var auth = new OAuth2AuthenticationToken(principal, principal.getAuthorities(), "github");
 
     mockMvc
         .perform(get("/welcome").with(SecurityMockMvcRequestPostProcessors.authentication(auth)))
         .andExpect(status().isOk())
-        .andExpect(content().string(containsString("Welcome, Test User")));
+        .andExpect(
+            content()
+                .string(
+                    containsString(
+                        "<h1 class=\"text-3xl font-bold mb-6\">Welcome to HobbyHub API</h1>")));
   }
 
   /** Test logout flows to “/” after signing out. */


### PR DESCRIPTION
The `/welcome` endpoint should present a styled landing page for developers. Replace the current with a minimal Tailwind HTML page listing useful links to API endpoints, diagnostics, and tools.

---

### **Issue**

Closes #49 

### **Acceptance Criteria**

* [x] `/welcome` returns a full HTML page with Tailwind styling
* [x] Links are grouped under **Swagger**, **Spanish**, **Weightlifting**, and **Ops**
* [x] The page is served without requiring OAuth
* [x] Works identically in `local` and `fly` profiles

### **Notes**

* Refactored `SecurityIntegrationTest` as `HomeController` has changed
* Did not add spanish and weightlifting links, it's confusing. Swagger takes care of it
