### PR TITLE
add Stoplight Elements link for public OpenAPI viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ HobbyHub API is a personal-skill tracker designed for hobbyists who want to deep
   1. Go to the **Actions** tab → select the latest **CI** run.  
   2. Under **Artifacts**, click **jacoco-report** to download.  
   3. Unzip and open `index.html` in a browser for class-by-class coverage details.
+
+## Developer Docs
+
+- [Swagger UI](https://hobbyhub-api.fly.dev/swagger-ui/index.html) – Live interactive playground
+- [Stoplight Elements](https://elements-demo.stoplight.io/?spec=https://hobbyhub-api.fly.dev/v3/api-docs) – Rendered OpenAPI spec for client SDK generation

--- a/src/main/java/com/andremunay/hobbyhub/HomeController.java
+++ b/src/main/java/com/andremunay/hobbyhub/HomeController.java
@@ -26,6 +26,8 @@ public class HomeController {
 
           <div class="grid gap-4">
             <a href="/swagger-ui/index.html" class="text-blue-600 hover:underline">Swagger UI</a>
+            <a href="https://elements-demo.stoplight.io/?spec=https://hobbyhub-api.fly.dev/v3/api-docs"
+              class="text-blue-600 hover:underline">Stoplight API Docs</a>
 
             <h2 class="text-xl font-semibold mt-6">Ops</h2>
             <a href="/actuator/metrics" class="text-blue-600 hover:underline">Actuator Metrics</a>


### PR DESCRIPTION
Expose the OpenAPI JSON at `/v3/api-docs` via SpringDoc and publish the spec using Stoplight Elements for easy client SDK generation and developer onboarding.

---

### **Issue**

Closes #55 

### **Acceptance Criteria**

* [x] `/v3/api-docs` is reachable on the production deployment
* [x] Spec is viewable at `https://elements.stoplight.io/?spec=https://hobbyhub-api.fly.dev/v3/api-docs`
* [x] Link added to `/welcome` and project README
